### PR TITLE
Fix unread check when last read time matches visible action

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -8079,7 +8079,7 @@ function isUnread(report: OnyxEntry<Report>, oneTransactionThreadReport: OnyxEnt
     const lastMentionedTime = report.lastMentionedTime ?? '';
 
     // If the user was mentioned and the comment got deleted the lastMentionedTime will be more recent than the lastVisibleActionCreated
-    return lastReadTime < (lastVisibleActionCreated ?? '') || lastReadTime < lastMentionedTime;
+    return lastReadTime <= (lastVisibleActionCreated ?? '') || lastReadTime < lastMentionedTime;
 }
 
 function isIOUOwnedByCurrentUser(report: OnyxEntry<Report>, allReportsDict?: OnyxCollection<Report>): boolean {

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -64,6 +64,7 @@ import {
     isPayer,
     isReportOutstanding,
     isRootGroupChat,
+    isUnread,
     parseReportRouteParams,
     prepareOnboardingOnyxData,
     requiresAttentionFromCurrentUser,
@@ -5606,6 +5607,20 @@ describe('ReportUtils', () => {
             Onyx.set(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails).then(() => {
                 expect(canSeeDefaultRoom(report, betas, false)).toBe(true);
             });
+        });
+    });
+
+    describe('isUnread', () => {
+        it('returns true when lastReadTime equals lastVisibleActionCreated', () => {
+            const timestamp = DateUtils.getDBTime();
+            const report: Report = {
+                reportID: '1',
+                type: CONST.REPORT.TYPE.CHAT,
+                lastVisibleActionCreated: timestamp,
+                lastReadTime: timestamp,
+                lastMessageText: 'hi',
+            } as unknown as Report;
+            expect(isUnread(report, undefined)).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
- mark report as unread when `lastReadTime` equals `lastVisibleActionCreated`
- avoid auto-reading actions when timestamps match

## Testing
- ⚠️ `npm ci` *(fails: Unsupported engine node 22.19.0)*
- ⚠️ `npm test tests/unit/ReportUtilsTest.ts tests/unit/ReportActionsUtilsTest.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c1ae459ef08330984a04a0c83b0af7