### PR TITLE
Fix unread message preview styling

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -135,8 +135,8 @@ function OptionRowLHN({
     const textUnreadStyle = shouldUseBoldText(optionItem) ? [textStyle, styles.sidebarLinkTextBold] : [textStyle];
     const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, textUnreadStyle, styles.flexShrink0, style];
     const alternateTextStyle = isInFocusMode
-        ? [textStyle, styles.textLabelSupporting, styles.optionAlternateTextCompact, styles.ml2, style]
-        : [textStyle, styles.optionAlternateText, styles.textLabelSupporting, style];
+        ? [textUnreadStyle, styles.textLabelSupporting, styles.optionAlternateTextCompact, styles.ml2, style]
+        : [textUnreadStyle, styles.optionAlternateText, styles.textLabelSupporting, style];
 
     const contentContainerStyles = isInFocusMode ? [styles.flex1, styles.flexRow, styles.overflowHidden, StyleUtils.getCompactContentContainerStyles()] : [styles.flex1];
     const hoveredBackgroundColor = !!styles.sidebarLinkHover && 'backgroundColor' in styles.sidebarLinkHover ? styles.sidebarLinkHover.backgroundColor : theme.sidebar;


### PR DESCRIPTION
## Summary
- ensure unread messages appear bold in left-hand navigation

## Testing
- `npm test tests/unit/SidebarTest.ts` *(fails: jest not found)*
- `npm ci` *(fails: Node engine 22 incompatible with required 20)*
- `npx --yes jest tests/unit/SidebarTest.ts` *(fails: Preset jest-expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c1bf9af07483309652b968563892c8