### PR TITLE
Fix unread LHN items not bold on desktop

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHNData.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHNData.tsx
@@ -3,6 +3,7 @@ import React, {useMemo, useRef} from 'react';
 import useCurrentReportID from '@hooks/useCurrentReportID';
 import useGetExpensifyCardFromReportAction from '@hooks/useGetExpensifyCardFromReportAction';
 import useOnyx from '@hooks/useOnyx';
+import {useSession} from '@components/OnyxListItemProvider';
 import {getSortedReportActions, shouldReportActionBeVisibleAsLastAction} from '@libs/ReportActionsUtils';
 import {canUserPerformWriteAction as canUserPerformWriteActionUtil} from '@libs/ReportUtils';
 import SidebarUtils from '@libs/SidebarUtils';
@@ -44,6 +45,7 @@ function OptionRowLHNData({
     const reportID = propsToForward.reportID;
     const currentReportIDValue = useCurrentReportID();
     const isReportFocused = isOptionFocused && currentReportIDValue?.currentReportID === reportID;
+    const session = useSession();
 
     const optionItemRef = useRef<OptionData | undefined>(undefined);
 
@@ -121,6 +123,7 @@ function OptionRowLHNData({
         isReportArchived,
         movedFromReport,
         movedToReport,
+        session?.accountID,
     ]);
 
     return (


### PR DESCRIPTION
## Summary
- Recompute LHN option data when session changes so unread items become bold on desktop

## Testing
- `npm run lint -- src/components/LHNOptionsList/OptionRowLHNData.tsx` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c282ed18833099292355ebb8da8f