### PR TITLE
feat: unify bold styling for OptionRow previews

### DIFF
--- a/src/components/OptionRow.tsx
+++ b/src/components/OptionRow.tsx
@@ -137,6 +137,7 @@ function OptionRow({
         textStyle,
         styles.optionAlternateText,
         styles.textLabelSupporting,
+        boldStyle || option.boldStyle ? styles.sidebarLinkTextBold : undefined,
         style,
         (option.alternateTextMaxLines ?? 1) === 1 ? styles.pre : styles.preWrap,
     ];


### PR DESCRIPTION
## Summary
- ensure OptionRow message preview uses bold text when unread, matching display name

## Testing
- `npm test -- --testPathPattern OptionRow --passWithNoTests` *(fails: Module jest-expo should have "jest-preset.js" or "jest-preset.json" file at the root)*

------
https://chatgpt.com/codex/tasks/task_b_68c1d20d82f48330b62ab36968616096